### PR TITLE
fix(mdToolbar): Prevent scrollbar from hiding when using scroll schrink

### DIFF
--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -169,6 +169,7 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate) {
 
           element.css($mdConstant.CSS.TRANSFORM, translateY([-y * shrinkSpeedFactor]));
           contentElement.css($mdConstant.CSS.TRANSFORM, translateY([(toolbarHeight - y) * shrinkSpeedFactor]));
+          contentElement.css('margin-bottom', (toolbarHeight - y) * shrinkSpeedFactor);
 
           prevScrollTop = scrollTop;
 
@@ -214,11 +215,11 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate) {
           //
           // As the user scrolls down, the content will be transformed up slowly
           // to put the content underneath where the toolbar was.
-          var margin = (-toolbarHeight * shrinkSpeedFactor) + 'px';
+          var margin = (-toolbarHeight * shrinkSpeedFactor);
 
           contentElement.css({
-            "margin-top": margin,
-            "margin-bottom": margin
+            "margin-top": margin + 'px',
+            "margin-bottom": -margin + 'px'
           });
 
           onContentScroll();


### PR DESCRIPTION
As it can be seen on the demo, when scroll shrink is enabled and the toolbar is visible, the bottom of the scrollbar is not visible. This PR fixes that bug.